### PR TITLE
Fixed tests hanging beucase of test DB clear

### DIFF
--- a/.branchoffrc
+++ b/.branchoffrc
@@ -44,7 +44,7 @@
     },
     "branch": {
       "default": {
-        "SOCKET_SERVER_PORT": 2996,
+        "SOCKET_SERVER_PORT": 2997,
         "SOCKET_SERVER_PATH": "",
         "SOCKET_SERVER_SEARCH": "?"
       },

--- a/tests/test-init.es6
+++ b/tests/test-init.es6
@@ -10,12 +10,16 @@ console.persistent('tags', []);
 global.TEST = path.basename(stack()[7].getFileName());
 
 export function clearDatabase() {
-  return new Promise(resolve => {
+  return new Promise((resolve, reject) => {
     for (const col in mongoose.connection.collections) { //eslint-disable-line
       mongoose.connection.collections[col].remove();
     }
 
-    resolve(models.sequelize.sync({force: true})); // Remove once we finalize model
+    models.sequelize.query('SET FOREIGN_KEY_CHECKS=0')
+          .then(() => models.sequelize.sync({force: true}))
+          .then(() => models.sequelize.query('SET FOREIGN_KEY_CHECKS=1'))
+          .then(() => resolve())
+          .catch(err => reject(err));
   });
 }
 


### PR DESCRIPTION
We need to remove foreign key constraint checks when dropping tables in entree_test since sequelize.sync() does not enforce any order.
